### PR TITLE
Fix NullPointer Exception

### DIFF
--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -517,13 +517,14 @@ public class GitImporter {
 	}
 
 	private Folder findFirstFolder(Folder f, String folderPattern) {
-		// Bread-first search queue
+		// Breadth-first search queue
 		Deque<Folder> deque = new ArrayDeque<Folder>();
 		deque.addLast(f);
 		while(!deque.isEmpty()) {
 			Folder folder = deque.removeFirst();
 			String path = folder.getFolderHierarchy();
 			path = path.replace('\\', '/');
+			folderPattern = folderPattern.replace('\\', '/');
 			int indexOfFirstPath = path.indexOf('/');
 
 			path = path.substring(indexOfFirstPath + 1);


### PR DESCRIPTION
Add a line of defensive code to ensure that both the path returned by
the getFolderHierarchy() and the folderPattern supplied are in the
same operating system directory seperator format.

Without this change if the pattern supplied is not in Unix directory
format the folder on StarTeam is never found. As in line 531 it never
starts with the folder pattern.